### PR TITLE
Removed htmlEncode from return message

### DIFF
--- a/src/Bots/CodeConversationsBot.cs
+++ b/src/Bots/CodeConversationsBot.cs
@@ -150,7 +150,7 @@ namespace CodeConversations.Bots
                                          else
                                          {
                                              var content = string.Join("\n", formattedValues.Select(f => f.Value));
-                                             var message = MessageFactory.Text($"```\n{content.HtmlEncode()}");
+                                             var message = MessageFactory.Text($"```\n{content}");
                                              context.SendActivityAsync(message, token).Wait();
                                          }
                                      }


### PR DESCRIPTION
This was causing text to come out as encoded entities, which is not pretty. According to #1 it's not needed anymore.

fixes #1